### PR TITLE
deployスクリプトでビルド前にビルドフォルダを削除する処理を追加

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -17,6 +17,9 @@ echo WORK_DIR=${WORK_DIR}
 echo DST_VER_DIR=${DST_VER_DIR}
 echo DST_LATEST_DIR=${DST_LATEST_DIR}
 
+# clean
+rm -rf ../doc/_build
+
 # build pdf
 make -C ../doc latexpdf
 cp "../doc/_build/latex/${PDF_NAME}" "../doc/${PDF_NAME}"


### PR DESCRIPTION
- ビルド前にフォルダを削除
- ダウンロード用ファイルなど、ビルド毎にフォルダ名が変わるファイルが残っているケースがあった
